### PR TITLE
Add basic OpenGL GLFW sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,19 @@
 cmake_minimum_required(VERSION 3.10)
-project(VectorscopeVisualizer LANGUAGES CXX)
+project(OpenGLWindow LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_executable(vectorscope
+add_executable(opengl_window
     src/main.cpp
 )
 
 find_package(OpenGL REQUIRED)
 find_package(glfw3 REQUIRED)
-find_package(Threads REQUIRED)
 
-# websocketpp and boost are optional; expected to be installed on system
-find_package(Boost REQUIRED COMPONENTS system thread)
-include_directories(${Boost_INCLUDE_DIRS})
-
- target_link_libraries(vectorscope PRIVATE
+target_link_libraries(opengl_window PRIVATE
     glfw
     OpenGL::GL
-    Threads::Threads
-    ${Boost_LIBRARIES}
 )
 
-install(TARGETS vectorscope RUNTIME DESTINATION bin)
+install(TARGETS opengl_window RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -1,30 +1,26 @@
-# Vectorscope Visualizer
+# OpenGL GLFW Example
 
-This project is a prototype stereo XY vectorscope built with C++17 for the backend and React for the frontend. The components communicate using WebSockets. Rendering is done with OpenGL and GLSL shaders.
+This repository contains a minimal C++17 application that opens a window using GLFW and clears the screen each frame with OpenGL. The project is designed to build with package managers like **vcpkg**, **MSYS2** or the standard packages available on Linux distributions.
 
 ## Folder Layout
 
 - `src/` — C++ source code
-- `src/shaders/` — Vertex and fragment shaders
-- `frontend/` — React application
 - `build/` — Generated binaries
+
+## Requirements
+- C++17 compiler
+- CMake 3.10+
+- `glfw` and OpenGL development libraries
 
 ## Building
 
-### Requirements
-- C++17 compiler
-- CMake 3.10+
-- `glfw` and `boost` installed on the system
-- Node.js (for the React frontend)
-
-### Linux / macOS
 ```bash
-./scripts/build_and_run.sh
+cmake -B build -S .
+cmake --build build
 ```
 
-### Windows
-```cmd
-scripts\\build_and_run.bat
-```
+Run the executable:
 
-This will build the backend and start the React development server.
+```bash
+./build/opengl_window
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,57 +1,32 @@
 #include <iostream>
-#include <thread>
-#include <websocketpp/config/asio_no_tls.hpp>
-#include <websocketpp/server.hpp>
 #include <GLFW/glfw3.h>
-
-using websocketpp::connection_hdl;
-typedef websocketpp::server<websocketpp::config::asio> server;
-
-class VectorscopeApp {
-public:
-    VectorscopeApp() {
-        ws_server.init_asio();
-        ws_server.set_message_handler([
-            this](connection_hdl hdl, server::message_ptr msg) {
-            // Echo received messages back to client
-            ws_server.send(hdl, msg->get_payload(), msg->get_opcode());
-        });
-    }
-
-    void run() {
-        ws_server.listen(9002);
-        ws_server.start_accept();
-        std::thread ws_thread([this]() { ws_server.run(); });
-
-        if (!glfwInit()) {
-            std::cerr << "Failed to init GLFW" << std::endl;
-            return;
-        }
-        GLFWwindow* window = glfwCreateWindow(800, 600, "Vectorscope", nullptr, nullptr);
-        if (!window) {
-            glfwTerminate();
-            return;
-        }
-        glfwMakeContextCurrent(window);
-        while (!glfwWindowShouldClose(window)) {
-            glClear(GL_COLOR_BUFFER_BIT);
-            // TODO: render vectorscope
-            glfwSwapBuffers(window);
-            glfwPollEvents();
-        }
-        glfwDestroyWindow(window);
-        glfwTerminate();
-
-        ws_server.stop();
-        ws_thread.join();
-    }
-
-private:
-    server ws_server;
-};
+#include <cstdlib>
 
 int main() {
-    VectorscopeApp app;
-    app.run();
-    return 0;
+    if (!glfwInit()) {
+        std::cerr << "Failed to initialize GLFW" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    GLFWwindow* window = glfwCreateWindow(800, 600, "OpenGL Window", nullptr, nullptr);
+    if (!window) {
+        glfwTerminate();
+        std::cerr << "Failed to create window" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    glfwMakeContextCurrent(window);
+
+    while (!glfwWindowShouldClose(window)) {
+        glClearColor(0.1f, 0.2f, 0.3f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glfwSwapBuffers(window);
+        glfwPollEvents();
+    }
+
+    glfwDestroyWindow(window);
+    glfwTerminate();
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary
- simplify the repository into a minimal GLFW + OpenGL example
- update the build file to only depend on OpenGL and glfw3
- refresh the README with build instructions for the new sample

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_688bdb24c50083259045629a3eeb0dde